### PR TITLE
fix: Use Node 22

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export class CertificateValidationRecordCleanup extends Construct {
       entry: join(__dirname, 'cleanup-certificate-validation-records.handler.js'),
       logGroup: this.getOrCreateLogGroup(),
       timeout: cdk.Duration.minutes(2),
-      runtime: cdk.aws_lambda.Runtime.NODEJS_20_X,
+      runtime: cdk.aws_lambda.Runtime.NODEJS_22_X,
       initialPolicy: [
         new cdk.aws_iam.PolicyStatement({
           actions: ['acm:DescribeCertificate'],


### PR DESCRIPTION
Node 20 is now end of life. This PR updates the lambda to use Node 22 instead.